### PR TITLE
Allow Linux JDK locator to find locally installed locations

### DIFF
--- a/src/main/java/net/covers1624/jdkutils/LinuxJavaLocator.java
+++ b/src/main/java/net/covers1624/jdkutils/LinuxJavaLocator.java
@@ -33,6 +33,9 @@ public class LinuxJavaLocator extends JavaLocator {
         findJavasInFolder(installs, Paths.get("/opt/jdk"));
         findJavasInFolder(installs, Paths.get("/opt/jdks"));
 
+        // Locally installed locations
+        findJavasInFolder(installs, Paths.get(System.getProperty("user.home"), ".local/jdks"));
+
         if (props.findGradleJdks) {
             // Gradle installed
             findJavasInFolder(installs, Paths.get(System.getProperty("user.home"), ".gradle/jdks"));


### PR DESCRIPTION
Allow Linux JDK Locator to find JDKs that are installed locally to the user.

Checks `$HOME/.local/jdks` as a search path.
